### PR TITLE
add a command to get a db from production and replace your local db

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $ wp wpe backup myinstall
 SUCCESS: Backup triggered! This can take a while! You will be notified at ryan.hoover@wpengine.com when the checkpoint has completed.
 ```
 
+Replace your local database with a fresh copy of a WP Engine install's database
+
+```bash
+$ wp wpe fetch-db myinstall
+Success: Imported from '/tmp/wpe-cli-fetch-db-1489176549.sql'.
+```
+
 ## Installation
 
 1. Open up the "advanced" tab in WP Engine Portal

--- a/php/class-wpe-cli-command.php
+++ b/php/class-wpe-cli-command.php
@@ -16,7 +16,7 @@ class WPE_CLI_Command extends WP_CLI_Command {
 	 * : The command to run on the install.
 	 *
 	 * [<field>...]
-	 * : The wp-cli commands needed.
+	 * : Extra wp-cli command arguments needed.
 	 *
 	 * [--staging]
 	 * : Run the command on the staging environment.

--- a/php/class-wpe-cli-command.php
+++ b/php/class-wpe-cli-command.php
@@ -36,7 +36,7 @@ class WPE_CLI_Command extends WP_CLI_Command {
 	 *
 	 * @when after_wp_load
 	 */
-	public function cli( $args, $assoc_args, $echo = true ) {
+	public function cli( $args, $assoc_args ) {
 		$install = array_shift( $args );
 
 		$environment = \WP_CLI\Utils\get_flag_value( $assoc_args, 'staging' ) ? 'staging' : 'production';
@@ -65,12 +65,7 @@ class WPE_CLI_Command extends WP_CLI_Command {
 		$json_res = json_decode( $res['body'] );
 
 		if ( $json_res && ! empty( $json_res->response ) ) {
-
-			if ( $echo ) {
-				WP_CLI::log( $json_res->response );
-			} else {
-				return $json_res->response;
-			}
+			WP_CLI::log( $json_res->response );
 		}
 	}
 


### PR DESCRIPTION
`wp wpe fetch-db myinstall`

Download the database from your WP Engine install and replace your local database with it.

Used for live sites in active development so you can catch up your local instance with the production instance.

A couple questions:

* What's a good command name for this? `fetch-db` seemed decent, but I'm not sure what to call it.
* Should I run a search-replace to swap out domain names? i.e., get the WPE install's domain and replace it with the local instance's domain: `wp search-replace mywebsite.com mywebsite.dev` (swapping can be automatically scripted as part of this command run without user input). 

The only reason I would say "no" to the search replace is that dev environments (should?) always have the domain hard coded in the config.